### PR TITLE
Align logo to center

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -2,11 +2,11 @@
 
 @section('content')
   <div class="section" id="index-banner">
-    <div class="container">
+    <div class="container center">
 
       <img src="/img/full-logo.png" alt="Laravel Collective"/>
 
-      <div class="row center">
+      <div class="row">
         <code class="col s6 offset-s3 thin">We maintain Laravel components that have been removed from the core framework, so you can continue to use the amazing Laravel features that you love.</code>
       </div>
 


### PR DESCRIPTION
A little visual improvement. 

Make a logo/banner to be aligned in center, rather than left.

Here are the images, before and after.

![before](https://cloud.githubusercontent.com/assets/534610/6222713/53b65c8a-b672-11e4-9a7b-5ac575108ba8.jpg)
![after](https://cloud.githubusercontent.com/assets/534610/6222712/53b35512-b672-11e4-8c21-5da8c6d22266.jpg)
