### PR TITLE
Fixes project buttons display on the homepage

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -15,23 +15,11 @@
 
   <div class="container">
     <div class="row center">
-      <div class="col s12 m1">&nbsp;</div>
-      <div class="col s12 m2">
         <a class="btn-large" href="{{route('docs.show', ['master', 'annotations'])}}">Annotations</a>
-      </div>
-      <div class="col s12 m2">
         <a class="btn-large" href="{{route('docs.show', ['master', 'html'])}}">HTML &amp; Forms</a>
-      </div>
-      <div class="col s12 m2">
         <a class="btn-large" href="{{route('docs.show', ['master', 'ssh'])}}">Remote (SSH)</a>
-      </div>
-      <div class="col s12 m2">
         <a class="btn-large" href="{{route('docs.show', ['master', 'iron-queue'])}}">Iron Queue</a>
-      </div>
-      <div class="col s12 m2">
         <a class="btn-large" href="{{route('docs.show', ['master', 'bus'])}}">Command Bus</a>
-      </div>
-      <div class="col s12 m1">&nbsp;</div>
     </div>
   </div>
 


### PR DESCRIPTION
Previous version has project buttons in columns, which causes text to cascade and out of the buttons:

![screen shot 2017-06-22 at 00 26 05](https://user-images.githubusercontent.com/349689/27410753-7338c7d4-56e1-11e7-861c-677d528a28cc.png)

Fixed by removing the columns:

![screen shot 2017-06-22 at 00 26 15](https://user-images.githubusercontent.com/349689/27410773-88fde8a6-56e1-11e7-94ef-ffb62c2c2297.png)



